### PR TITLE
Support template chooser configuration

### DIFF
--- a/src/assets/extra.scss
+++ b/src/assets/extra.scss
@@ -8,6 +8,11 @@
   --ghf-color-button-primary-hover-border: rgb(27 31 36 / 15%);
   --ghf-color-button-border: rgb(27 31 36 / 15%);
   --ghf-color-button-bg: #f6f8fa;
+  --ghf-color-button-text: #24292f;
+  --ghf-color-button-shadow: 0 1px 0 rgba(27,31,36,0.04);
+  --ghf-color-button-inset-shadow: inset 0 1px 0 rgba(255,255,255,0.25);
+  --ghf-color-button-hover-bg: #f3f4f6;
+  --ghf-color-button-hover-border: rgb(27 31 36 / 15%);
   --ghf-color-canvas-overlay: #ffffff;
   --ghf-color-neutral-subtle: rgb(234 238 242 / 50%);
 }
@@ -207,6 +212,19 @@ textarea[lang] {
     &:hover {
       background-color: var(--ghf-color-button-primary-hover-bg);
       border-color: var(--ghf-color-button-primary-hover-border);
+      text-decoration: none;
+    }
+
+    &.external {
+      color: var(--ghf-color-button-text);
+      background-color: var(--ghf-color-button-bg);
+      border-color: var(--ghf-color-button-border);
+      box-shadow: var(--ghf-color-button-shadow), var(--ghf-color-button-inset-shadow);
+    }
+
+    &.external:hover {
+      background-color: var(--ghf-color-button-hover-bg);
+      border-color: var(--ghf-color-button-hover-border);
       text-decoration: none;
     }
   }

--- a/src/assets/extra.scss
+++ b/src/assets/extra.scss
@@ -164,6 +164,11 @@ textarea[lang] {
   background-color: var(--color-canvas-default);
   border: 1px solid var(--color-border-default);
   border-radius: 6px;
+
+  & ~ div.footnote {
+    padding-top: 16px;
+    font-size: 14px;
+  }
 }
 
 .summary {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -53,7 +53,7 @@ pub async fn top_page(Extension(state): Extension<Arc<AppState>>) -> impl IntoRe
                         href="/assets/extra.css";
                     body ."markdown-body" {
                         div."form-list-container" {
-                            @for yaml in value {
+                            @for yaml in value.iter().filter(|x| x != &"config.yml") {
                                 (issue::form::deserialize(&*state.directory.join(&yaml).to_string_lossy())
                                     .map_or_else(
                                         |err| {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -71,11 +71,12 @@ pub async fn top_page(Extension(state): Extension<Arc<AppState>>) -> impl IntoRe
                                     )
                                 )
                             }
-                            @if let Some(c) = config {
-                                (c.map_or_else(
-                                    |err| {
+                            @if let Some(ref c) = config {
+                                (match c {
+                                    Ok(val)=>{val.render()}
+                                    Err(err)=>{
                                         warn!("Failed to deserialize config.yml");
-                                        html! {
+                                        html!{
                                             div.summary {
                                                 div {
                                                     div {(format!("Failed to deserialize config.yml"))}
@@ -83,9 +84,13 @@ pub async fn top_page(Extension(state): Extension<Arc<AppState>>) -> impl IntoRe
                                                 }
                                             }
                                         }
-                                    },
-                                    |val| val.render()
-                                ))
+                                    }
+                                })
+                            }
+                        }
+                        @if let Some(Ok(c)) = config {
+                            @if let Some(footnote) = c.footnote() {
+                                (footnote)
                             }
                         }
                     }

--- a/src/issue.rs
+++ b/src/issue.rs
@@ -1,0 +1,2 @@
+pub mod config;
+pub mod form;

--- a/src/issue/config.rs
+++ b/src/issue/config.rs
@@ -10,13 +10,13 @@ pub fn deserialize(file: impl AsRef<Path> + Display + Copy) -> Result<Config> {
     return Ok(config);
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct Config {
     blank_issues_enabled: bool,
     contact_links: Vec<ContactLink>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 struct ContactLink {
     name: String,
     url: String,
@@ -39,6 +39,16 @@ impl Render for Config {
                         {"Open"}
                 }
             }
+        }
+    }
+}
+
+impl Config {
+    pub fn footnote(&self) -> Option<Markup> {
+        if self.blank_issues_enabled {
+            Some(html! { div.footnote {"Don't see your issue here? Open a blank issue."} })
+        } else {
+            None
         }
     }
 }

--- a/src/issue/config.rs
+++ b/src/issue/config.rs
@@ -1,0 +1,44 @@
+use std::{fmt::Display, fs, path::Path};
+
+use anyhow::{Context, Result};
+use maud::{html, Markup, Render};
+use serde::Deserialize;
+
+pub fn deserialize(file: impl AsRef<Path> + Display + Copy) -> Result<Config> {
+    let f = fs::File::open(file).with_context(|| format!("Failed to open {}", file))?;
+    let config: Config = serde_yaml::from_reader(f)?;
+    return Ok(config);
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    blank_issues_enabled: bool,
+    contact_links: Vec<ContactLink>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ContactLink {
+    name: String,
+    url: String,
+    about: String,
+}
+
+impl Render for Config {
+    fn render(&self) -> Markup {
+        html! {
+            @for contact_link in &self.contact_links {
+                div.summary {
+                    div {
+                        strong.name {(contact_link.name)}
+                        div.description {(contact_link.about)}
+                    }
+                    a.button.external
+                        href=(contact_link.url)
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        {"Open"}
+                }
+            }
+        }
+    }
+}

--- a/src/issue/config.rs
+++ b/src/issue/config.rs
@@ -10,13 +10,13 @@ pub fn deserialize(file: impl AsRef<Path> + Display + Copy) -> Result<Config> {
     return Ok(config);
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct Config {
     blank_issues_enabled: bool,
     contact_links: Vec<ContactLink>,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Debug, Deserialize)]
 struct ContactLink {
     name: String,
     url: String,

--- a/src/issue/form.rs
+++ b/src/issue/form.rs
@@ -8,14 +8,14 @@ use std::{
     path::Path,
 };
 
-pub fn deserialize(file: impl AsRef<Path> + Display + Copy) -> Result<IssueForm> {
+pub fn deserialize(file: impl AsRef<Path> + Display + Copy) -> Result<Form> {
     let f = fs::File::open(file).with_context(|| format!("Failed to open {}", file))?;
-    let form: IssueForm = serde_yaml::from_reader(f)?;
+    let form: Form = serde_yaml::from_reader(f)?;
     return Ok(form);
 }
 
 #[derive(Debug, Deserialize)]
-pub struct IssueForm {
+pub struct Form {
     name: String,
     description: String,
     // The optional title is in the issue form's spec, but is not used
@@ -30,7 +30,7 @@ pub struct IssueForm {
     body: Vec<BodyType>,
 }
 
-impl IssueForm {
+impl Form {
     pub fn to_html(&self) -> Markup {
         html! {
             (DOCTYPE)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 mod commands;
-mod form;
 mod handlers;
+mod issue;
 
 use std::{net::SocketAddr, sync::Arc};
 


### PR DESCRIPTION
SSIA (cf. [docs for template chooser](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser)).

ToDo:

- [x] don't log a warning when `config.yml` is absent
- [x] don't try to preview `config.yml`