### PR TITLE
Set up release pipeline

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Bug Fixes
+      labels:
+        - bug fix
+    - title: New Features
+      labels:
+        - enhancement
+    - title: Misc
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           draft: false
+          generate_release_notes: true
           prerelease: false
           files: |
             dist/gh-form_${{ env.TAG }}_darwin-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: release
+name: Publish a new release
 on:
   push:
     tags:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,26 @@
+name: tag
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - Cargo.toml
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - uses: salsify/action-detect-and-tag-new-version@v2
+        id: version-detection
+        with:
+          create-tag: false
+          version-command: cargo read-manifest | jq -r .version
+      - uses: mathieudutour/github-tag-action@v5
+        with:
+          custom_tag: ${{ steps.version-detection.outputs.current-version }}
+          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        if: ${{ steps.version-detection.outputs.previous-version != steps.version-detection.outputs.current-version }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -8,8 +8,11 @@ on:
       - Cargo.toml
 
 jobs:
+  token:
+    uses: yudai-nkt/reusable-workflows/.github/workflows/github-apps-token@179ee0565db14332b6ffaa503159ac2473cbcc68
   tag:
     runs-on: ubuntu-latest
+    needs: token
     steps:
       - uses: actions/checkout@v2
         with:
@@ -22,5 +25,5 @@ jobs:
       - uses: mathieudutour/github-tag-action@v6
         with:
           custom_tag: ${{ steps.version-detection.outputs.current-version }}
-          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          github_token: ${{ needs.token.outputs.token }}
         if: ${{ steps.version-detection.outputs.previous-version != steps.version-detection.outputs.current-version }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           create-tag: false
           version-command: cargo read-manifest | jq -r .version
-      - uses: mathieudutour/github-tag-action@v5
+      - uses: mathieudutour/github-tag-action@v6
         with:
           custom_tag: ${{ steps.version-detection.outputs.current-version }}
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,4 +1,4 @@
-name: tag
+name: Tag a new version
 
 on:
   push:


### PR DESCRIPTION
This PR set up an automated release pipeline:

- `tag` workflow is introduced, which creates a new tag if the `version` field in `Cargo.toml` is updated
- `release` workflow now generates a release note

ToDo:

- ~set up PAT in the repo setting~ (not required thanks to 738527241b3b38b021ceac2161b822e9d58f5634)